### PR TITLE
Fixes for 32-bit Swift (arm)

### DIFF
--- a/Sources/NetTCP.swift
+++ b/Sources/NetTCP.swift
@@ -23,7 +23,8 @@ import PerfectThread
 import SwiftGlibc
 let AF_UNSPEC: Int32 = 0
 let AF_INET: Int32 = 2
-let INADDR_NONE = UInt32(0xffffffff)
+let INADDR_CONST: UInt64 = 0xffffffff
+let INADDR_NONE = UInt32(truncatingBitPattern: INADDR_CONST)
 let EINPROGRESS = Int32(115)
 #else
 import Darwin

--- a/Sources/NetTCPSSL.swift
+++ b/Sources/NetTCPSSL.swift
@@ -210,7 +210,11 @@ public class NetTCPSSL : NetTCP {
 		SSL_CTX_ctrl(sslCtx, SSL_CTRL_SET_ECDH_AUTO, 1, nil)
 	#endif
 		SSL_CTX_ctrl(sslCtx, SSL_CTRL_MODE, SSL_MODE_AUTO_RETRY, nil)
-		SSL_CTX_ctrl(sslCtx, SSL_CTRL_OPTIONS, SSL_OP_ALL, nil)
+        #if arch(arm)
+                SSL_CTX_ctrl(sslCtx, SSL_CTRL_OPTIONS, Int(bitPattern: SSL_OP_ALL), nil)
+	#else
+                SSL_CTX_ctrl(sslCtx, SSL_CTRL_OPTIONS, SSL_OP_ALL, nil)
+        #endif
 	}
 
 	public func errorCode() -> UInt {


### PR DESCRIPTION
These changes are a bit ugly.  The issue with INADDR_CONST is that I have to tell Swift very explicitly (this feels like a swift bug to me) the bit pattern type.  The literal constant is stubbornly interpreted as a Int, which being 32-bit, would overflow (swift protects the sign bit).

The change to NetTCPSSL.swift is because the api is slightly different.  So, this just traps the arm case and coerces the type.
