### PR TITLE
TLS version as a choice (by default still 1.2)

### DIFF
--- a/Sources/NetTCPSSL.swift
+++ b/Sources/NetTCPSSL.swift
@@ -44,6 +44,12 @@ public struct OpenSSLVerifyMode: OptionSet {
   public static let sslVerifyPeerWithFailIfNoPeerCertClientOnce: OpenSSLVerifyMode = [.sslVerifyPeer, .sslVerifyFailIfNoPeerCert, .sslVerifyClientOnce]
 }
 
+public enum TLSMethod {
+	case tlsV1_2
+	case tlsV1_1
+	case tlsV1
+}
+
 public class NetTCPSSL : NetTCP {
 
 	public static var opensslVersionText : String {
@@ -122,6 +128,8 @@ public class NetTCPSSL : NetTCP {
 	private var sslCtx: UnsafeMutablePointer<SSL_CTX>?
 	private var ssl: UnsafeMutablePointer<SSL>?
 
+	public var tlsMethod: TLSMethod = .tlsV1_2
+
 	public var keyFilePassword: String = "" {
 		didSet {
 			if !self.keyFilePassword.isEmpty {
@@ -135,7 +143,7 @@ public class NetTCPSSL : NetTCP {
 						return 0
 					}
 					
-                    let crl = Unmanaged<NetTCPSSL>.fromOpaque(UnsafeMutableRawPointer(userDataCheck)).takeUnretainedValue()
+					let crl = Unmanaged<NetTCPSSL>.fromOpaque(UnsafeMutableRawPointer(userDataCheck)).takeUnretainedValue()
 					return crl.passwordCallback(bufCheck, size: size, rwflag: rwflag)
 				}
 
@@ -234,7 +242,13 @@ public class NetTCPSSL : NetTCP {
 		guard self.sslCtx == nil else {
 			return
 		}
-		self.sslCtx = SSL_CTX_new(TLSv1_2_method())
+
+		switch self.tlsMethod {
+		case .tlsV1_2: self.sslCtx = SSL_CTX_new(TLSv1_2_method())
+		case .tlsV1_1: self.sslCtx = SSL_CTX_new(TLSv1_1_method())
+		case .tlsV1: self.sslCtx = SSL_CTX_new(TLSv1_method())
+		}
+		
 		guard let sslCtx = self.sslCtx else {
 			return
 		}


### PR DESCRIPTION
Picking the TLS version for the socket is now a choice. It has to be picked before the initSocket.
(Indentation fix as well so it's compatible with the rest of the file)