### PR TITLE
multi fallback server to *

### DIFF
--- a/Sources/NetTCPSSL.swift
+++ b/Sources/NetTCPSSL.swift
@@ -797,6 +797,9 @@ extension NetTCPSSL {
 			if let fndCtx = parent.sniContextMap[serverName] {
 				SSL_set_SSL_CTX(ssl, fndCtx.sslCtx)
 				child.trackCtx = fndCtx
+			} else if let fndCtx = parent.sniContextMap["*"] {
+				SSL_set_SSL_CTX(ssl, fndCtx.sslCtx)
+				child.trackCtx = fndCtx
 			}
 			return 1
 		}


### PR DESCRIPTION
Server name can be specified as * to handle any otherwise unhandled TLS traffic, such as with a wildcard cert. 