### PR TITLE
Fixes for 32-bit Swift (arm) FIXED

### DIFF
--- a/Sources/PerfectNet/NetTCPSSL.swift
+++ b/Sources/PerfectNet/NetTCPSSL.swift
@@ -234,7 +234,11 @@ public class NetTCPSSL : NetTCP {
 			SSL_CTX_ctrl(sslCtx, SSL_CTRL_SET_ECDH_AUTO, 1, nil)
 		#endif
 		SSL_CTX_ctrl(sslCtx, SSL_CTRL_MODE, SSL_MODE_AUTO_RETRY, nil)
-		SSL_CTX_ctrl(sslCtx, SSL_CTRL_OPTIONS, SSL_OP_ALL, nil)
+        #if arch(arm)
+            SSL_CTX_ctrl(sslCtx, SSL_CTRL_OPTIONS, Int(bitPattern: SSL_OP_ALL), nil)
+        #else
+            SSL_CTX_ctrl(sslCtx, SSL_CTRL_OPTIONS, SSL_OP_ALL, nil)
+        #endif
 		return sslCtx
 	}
 	


### PR DESCRIPTION
fixes for arm build. 
+ SSL_CTX_ctrl(sslCtx, SSL_CTRL_OPTIONS, Int(bitPattern: SSL_OP_ALL), nil)
- SSL_CTX_ctrl(sslCtx, SSL_CTRL_OPTIONS, SSL_OP_ALL, nil)

done by arch-check.
